### PR TITLE
Ruby 1.9 support.

### DIFF
--- a/lib/vydumschik/address.rb
+++ b/lib/vydumschik/address.rb
@@ -10,14 +10,14 @@ module Vydumschik
     # Maximum number of apartments in building
     MAX_APT = 100
 
-    # Maximum number of buildings for different types of streets 
+    # Maximum number of buildings for different types of streets
     BUILDING_LIMITS = {:street => 50, :alley => 10, :avenue => 120, :square => 10, :other => 20}
 
     # Probability of building without apartments
-    HOUSE_PROBABILITY = 0.2 
+    HOUSE_PROBABILITY = 0.2
 
     # Probability of building number having a  modifier
-    MODIFIER_PROBABILITY = 0.05 
+    MODIFIER_PROBABILITY = 0.05
 
     # Building number modifiers
     BUILDING_MODIFIERS = %w(а б в г д)
@@ -54,8 +54,15 @@ module Vydumschik
     private
 
     def self.data
-      @data ||= YAML.load_file(File.expand_path('../../../data/addresses.yml', __FILE__))
+      unless @data
+        @data = YAML.load_file(File.expand_path('../../../data/addresses.yml', __FILE__))
+        encode_data_to_utf8 if RUBY_VERSION >= '1.9'
+      end
+      @data
+    end
+
+    def self.encode_data_to_utf8
+      @data[:streets].each {|s| s[:name].force_encoding('utf-8') }
     end
   end
 end
-

--- a/lib/vydumschik/lorem.rb
+++ b/lib/vydumschik/lorem.rb
@@ -6,8 +6,8 @@ module Vydumschik
   # This module generate lipsum-like russian pseudosentences.
   #
   # Warning!
-  # To avoid using ActiveSupport for multibyte support, or anything similar, 
-  # I just assume that all russian chars are 2-byte (as in UTF8) and that I 
+  # To avoid using ActiveSupport for multibyte support, or anything similar,
+  # I just assume that all russian chars are 2-byte (as in UTF8) and that I
   # always get a russian char when I ask for one.
   module Lorem
 
@@ -28,7 +28,7 @@ module Vydumschik
 
     # Consonants, normalized by character frequency
     CONSONANTS_NORMALIZED = %w(б б б б б б б б б б б б б б б б б б б в в в в в в в в в в в в в в в в в в в в в в в в в в в в в в в в в в в в в в в в в в в в в в в в г г г г г г г г г г г г г г г г г г г д д д д д д д д д д д д д д д д д д д д д д д д д д д д д д д д ж ж ж ж ж ж ж ж ж ж ж ж з з з з з з з з з з з з з з з з з з й й й й й й й й й й й к к к к к к к к к к к к к к к к к к к к к к к к к к к к к к к к к к к к л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л л м м м м м м м м м м м м м м м м м м м м м м м м м м м м м м м м н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н н п п п п п п п п п п п п п п п п п п п п п п п п п п р р р р р р р р р р р р р р р р р р р р р р р р р р р р р р р р р р р р р р р р р р р р р с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с с т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т т ф х х х х х х х х ц ц ц ч ч ч ч ч ч ч ч ч ч ч ч ч ч ч ч ч ч ш ш ш ш ш ш ш ш ш щ щ щ)
-    
+
     # Vowels, normalized by character frequency
     VOWELS_NORMALIZED = %w(а а а а а а а а а а а а а а а а а а а а а а а а а а а а е е е е е е е е е е е е е е е е е е е е е е е е е е е е е е е и и и и и и и и и и и и и и и и и и и и и и о о о о о о о о о о о о о о о о о о о о о о о о о о о о о о о о о о о о о о о у у у у у у у у у ы ы ы ы ы ы э ю ю я я я я я я я)
 
@@ -82,10 +82,14 @@ module Vydumschik
     # Capitalizes a russian string. Works only with UTF8.
     def self.capitalize_ru(word)
       w = word.clone
-      code = (w[1]-0b10000000) + ((w[0]-0b11000000)<<6)
-      code -= 32
-      w[1] = (code & 0b00111111) | 0b10000000
-      w[0] = (code >> 6) | 0b11000000
+      if RUBY_VERSION >= '1.9'
+        w[0] = (w[0].ord - 32).chr('utf-8')
+      else
+        code = (w[1]-0b10000000) + ((w[0]-0b11000000)<<6)
+        code -= 32
+        w[1] = (code & 0b00111111) | 0b10000000
+        w[0] = (code >> 6) | 0b11000000
+      end
       w
     end
   end

--- a/lib/vydumschik/name.rb
+++ b/lib/vydumschik/name.rb
@@ -27,7 +27,7 @@ module Vydumschik
       surname += 'а' if gender==:female
       surname
     end
-    
+
     # Random full name - surname, first name and middle name (gender = :male/:female/nil for random)
     def self.full_name(gender=nil)
       gender ||= random_gender
@@ -37,11 +37,25 @@ module Vydumschik
     private
 
     def self.data
-      @data ||= YAML.load_file(File.expand_path('../../../data/names.yml', __FILE__))
+      unless @data
+        @data = YAML.load_file(File.expand_path('../../../data/names.yml', __FILE__))
+        encode_data_to_utf8 if RUBY_VERSION >= '1.9'
+      end
+      @data
     end
 
     def self.random_gender
       rand>0.5 ? :female : :male
+    end
+
+    def self.encode_data_to_utf8
+      @data[:male].each do |s|
+        s[:male_middle].force_encoding('utf-8')
+        s[:female_middle].force_encoding('utf-8')
+        s[:name].force_encoding('utf-8')
+      end
+      @data[:female].each {|s| s.force_encoding('utf-8') }
+      @data[:surnames].each {|s| s.force_encoding('utf-8') }
     end
   end
 end


### PR DESCRIPTION
1. Forced encoding of loaded data to utf-8.
2. Fixed Vydumschik::Lorem.capitalize_ru(word) method.

Tested on MRI 1.8.7-p357, 1.9.1-p431, 1.9.2-p290, 1.9.3-p0.
